### PR TITLE
discard curatedgo.com in copycats goggle

### DIFF
--- a/goggles/copycats_removal.goggle
+++ b/goggles/copycats_removal.goggle
@@ -174,6 +174,7 @@ $discard,site=zsharp.org
 $discard,site=awesomeopensource.com
 $discard,site=bestofcpp.com
 $discard,site=bleepcoder.com
+$discard,site=curatedgo.com
 $discard,site=findbestopensource.com
 $discard,site=gitanswer.com
 $discard,site=giters.com


### PR DESCRIPTION
https://curatedgo.com/r/want-to-mess-tilt-devctlptl/index.html
Seems to just copy the readme and issues.